### PR TITLE
feat: set build target to es2018 to drop filesize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Cache node modules
         uses: actions/cache@v1
         env:

--- a/packages/ga4/babel.config.js
+++ b/packages/ga4/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/packages/ga4/jest.config.js
+++ b/packages/ga4/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
   coverageThreshold: {
     global: {
-      statements: 72,
-      branches: 67,
-      functions: 81,
-      lines: 71,
+      statements: 97,
+      branches: 75,
+      functions: 100,
+      lines: 96,
     },
   },
   transform: {

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "url": "git+https://github.com/jahilldev/minimal-analytics.git"
   },
+  "engines": {
+    "node": ">=16.3.0"
+  },
   "scripts": {
     "start": "run-s clean watch",
     "build": "webpack --mode=production",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -68,7 +68,7 @@ const eventKeys = {
  *
  * -------------------------------- */
 
-function getArguments(...args: any[]): [string, IProps] {
+function getArguments(args: any[]): [string, IProps] {
   const globalId = window.minimalAnalytics?.trackingId;
   const trackingId = typeof args[0] === 'string' ? args[0] : globalId;
   const props = typeof args[0] === 'object' ? args[0] : args[1] || {};

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -340,7 +340,7 @@ function bindEvents(trackingId: string) {
 function track(trackingId: string, props?: IProps);
 function track(props?: IProps);
 function track(...args: any[]) {
-  const [trackingId, { type, event, debug, error }] = getArguments(...args);
+  const [trackingId, { type, event, debug, error }] = getArguments(args);
 
   if (!trackingId) {
     console.error('GA4: Tracking ID is missing or undefined');

--- a/packages/ga4/webpack.config.ts
+++ b/packages/ga4/webpack.config.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 const outputFiles = [
   // { target: 'es5', filename: '[name].es5.js' },
-  { target: 'es2016', filename: '[name].js' },
+  { target: 'es2018', filename: '[name].js' },
 ];
 
 /* -----------------------------------

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "module": "esnext"
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
- Configured `ga4` package to build ES2018 by default
- Changed module type to `esnext` for tree shaking of `shared` package
- Reduced GZipped size by ~120bytes