### PR TITLE
feat: added ability to override analyticsEndpoint value

### DIFF
--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -8,7 +8,7 @@ This is intended for those who want to minimize the impact of third-party JavaSc
 
 # Getting Started
 
-**N.B.** The instructions below assume a Node environment is available. If you're not running or building your application in a Node environment, jump to the [CDN section](#cdn). 
+**N.B.** The instructions below assume a Node environment is available. If you're not running or building your application in a Node environment, jump to the [CDN section](#cdn).
 
 Install with Yarn:
 
@@ -59,8 +59,6 @@ To call `track` without a tracking ID, it must be defined on the window via `tra
 
 The default event type of `page_view` can be overriden by providing the relevant argument to the `track` function. The interface for this [can be found here](https://github.com/jahilldev/minimal-analytics/blob/main/packages/ga4/src/index.ts#L24).
 
-
-
 ```ts
 // "type" and "event" can contain anything
 track({ type: 'user_signup', event: { 'user.id': 12345 });
@@ -78,6 +76,18 @@ window.minimalAnalytics = {
 ```
 
 Once the `ga4` script has loaded, `track` will automatically be called with the tracking ID defined above. You _must_ ensure both `trackingId` and `autoTrack` are properly defined for this to work.
+
+## Endpoint
+
+If you need to define your own collection endpoint, to proxy or record values yourself, you can use the following property:
+
+```js
+window.minimalAnalytics = {
+  analyticsEndpoint: '/collect', // <-- your endpoint
+};
+```
+
+This value will supercede the default Google Analytics endpoint if defined.
 
 # CDN
 

--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -8,7 +8,7 @@ This is intended for those who want to minimize the impact of third-party JavaSc
 
 # Getting Started
 
-**N.B.** The instructions below assume a Node environment is available. If you're not running or building your application in a Node environment, jump to the [CDN section](#cdn).
+**N.B.** The instructions below assume a Node environment is available. If you're not running or building your application in Node, jump to the [CDN section](#cdn).
 
 Install with Yarn:
 

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A tiny (1KB GZipped) version of GA4, complete with page view, engagement and scroll tracking",
   "author": "James Hill <jahill@groupon.com>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -15,6 +15,7 @@ import {
 declare global {
   interface Window {
     minimalAnalytics?: {
+      analyticsEndpoint?: string;
       trackingId?: string;
       autoTrack?: boolean;
     };
@@ -279,8 +280,9 @@ function track(...args: any[]) {
   }
 
   const queryParams = getQueryParams(trackingId, { type, event, debug, error });
+  const endpoint = window.minimalAnalytics?.analyticsEndpoint || analyticsEndpoint;
 
-  navigator.sendBeacon(`${analyticsEndpoint}?${queryParams}`);
+  navigator.sendBeacon(`${endpoint}?${queryParams}`);
 
   bindEvents(trackingId);
 }

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -118,6 +118,8 @@ describe('ga4 -> track()', () => {
 
     track(trackingId);
 
+    delete window.minimalAnalytics;
+
     expect(navigator.sendBeacon).toBeCalledTimes(1);
     expect(navigator.sendBeacon).toBeCalledWith(expect.stringContaining(testEndpoint));
   });

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -11,7 +11,7 @@ const analyticsEndpoint = 'https://www.google-analytics.com/g/collect';
 const analyticsVersion = '2';
 const errorTrackingId = 'GA4: Tracking ID is missing or undefined';
 const testTitle = 'testTitle';
-const testReferrer = 'https://google.com';
+const testUrl = 'https://google.com';
 const testLanguage = 'en-gb';
 const testColour = 32;
 const testWidth = 1600;
@@ -46,7 +46,7 @@ describe('ga4 -> track()', () => {
 
   Object.defineProperties(document, {
     referrer: {
-      value: testReferrer,
+      value: testUrl,
     },
     title: {
       value: testTitle,
@@ -83,7 +83,7 @@ describe('ga4 -> track()', () => {
       `tid=${trackingId}`,
       `ul=${testLanguage}`,
       'en=page_view',
-      `dr=${encodeURIComponent(testReferrer)}`,
+      `dr=${encodeURIComponent(testUrl)}`,
       `dt=${encodeURIComponent(testTitle)}`,
       `sd=${testColour}-bit`,
     ];
@@ -107,6 +107,19 @@ describe('ga4 -> track()', () => {
     params.forEach((param) =>
       expect(navigator.sendBeacon).toBeCalledWith(expect.stringContaining(param))
     );
+  });
+
+  it('uses the supplied analytics endpoint if defined on the window', () => {
+    const testEndpoint = `${testUrl}/collect/${Math.random()}`;
+
+    window.minimalAnalytics = {
+      analyticsEndpoint: testEndpoint,
+    };
+
+    track(trackingId);
+
+    expect(navigator.sendBeacon).toBeCalledTimes(1);
+    expect(navigator.sendBeacon).toBeCalledWith(expect.stringContaining(testEndpoint));
   });
 
   it('triggers a tracking event once when scroll is 90% of window', async () => {


### PR DESCRIPTION
- Added additional config property to window, `analyticsEndpoint`.
- Use defined override if available, falling back to default API.
- Updated `README` with details