### PR TITLE
feat: refactored ga4 data structures to use tuples

### DIFF
--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -1,6 +1,6 @@
 # @minimal-analytics/ga4
 
-This package is a slimmed down (**1KB GZipped**), drop-in replacement for the official Google Analytics 4 library. It provides page view tracking, engagement time and scroll events. Custom events can be handled in your application by calling `track` with your custom event type when needed.
+This package is a slimmed down (**2KB GZipped**), drop-in replacement for the official Google Analytics 4 library. It provides page view tracking, engagement time and scroll events. Custom events can be handled in your application by calling `track` with your custom event type when needed.
 
 The package works by calling the Google Analytics API directly, no further integrations like GTM are required.
 

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.4.5",
-  "description": "A tiny (1KB GZipped) version of GA4, complete with page view, engagement and scroll tracking",
+  "version": "1.4.6",
+  "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement and scroll tracking",
   "author": "James Hill <jahill@groupon.com>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",
   "license": "MIT",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -144,8 +144,7 @@ function getQueryParams(trackingId: string, { type, event, debug }: IProps) {
   ];
 
   payload = payload.concat(getEventMeta({ type, event }));
-
-  payload.forEach(([, value], index) => value || delete payload[index]);
+  payload = payload.filter(([, value]) => value);
 
   return new URLSearchParams(payload);
 }

--- a/packages/ga4/src/model.ts
+++ b/packages/ga4/src/model.ts
@@ -1,0 +1,34 @@
+/* -----------------------------------
+ *
+ * Param
+ *
+ * -------------------------------- */
+
+const param = {
+  protocolVersion: 'v',
+  trackingId: 'tid',
+  pageId: '_p',
+  language: 'ul',
+  clientId: 'cid',
+  firstVisit: '_fv',
+  hitCount: '_s',
+  sessionId: 'sid',
+  sessionCount: 'sct',
+  sessionEngagement: 'seg',
+  sessionStart: '_ss',
+  debug: '_dbg',
+  referrer: 'dr',
+  location: 'dl',
+  title: 'dt',
+  eventName: 'en',
+  eventParam: 'ep.',
+  screenResolution: 'sr',
+};
+
+/* -----------------------------------
+ *
+ * Export
+ *
+ * -------------------------------- */
+
+export { param };

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -14,7 +14,6 @@ const errorTrackingId = 'GA4: Tracking ID is missing or undefined';
 const testTitle = 'testTitle';
 const testUrl = 'https://google.com';
 const testLanguage = 'en-gb';
-const testColour = 32;
 const testWidth = 1600;
 const testHeight = 900;
 const testEvent = 'custom_event';
@@ -59,7 +58,7 @@ describe('ga4 -> track()', () => {
   });
 
   Object.defineProperty(self, 'screen', {
-    value: { width: testWidth, height: testHeight, colorDepth: testColour },
+    value: { width: testWidth, height: testHeight },
   });
 
   beforeEach(() => jest.resetAllMocks());
@@ -86,7 +85,6 @@ describe('ga4 -> track()', () => {
       'en=page_view',
       `dr=${encodeURIComponent(testUrl)}`,
       `dt=${encodeURIComponent(testTitle)}`,
-      `sd=${testColour}-bit`,
     ];
 
     track(trackingId);

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,0 +1,27 @@
+/* -----------------------------------
+ *
+ * Jest
+ *
+ * -------------------------------- */
+
+module.exports = {
+  testEnvironment: 'jsdom',
+  globals: { __DEV__: true },
+  roots: ['<rootDir>'],
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
+  coverageDirectory: '<rootDir>/tests/coverage',
+  coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
+  coverageThreshold: {
+    global: {
+      statements: 56,
+      branches: 50,
+      functions: 40,
+      lines: 50,
+    },
+  },
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\js$': 'babel-jest',
+  },
+};

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -15,9 +15,11 @@ function debounce(callback: TimerHandler, frequency = 500, timer = 0) {
  * -------------------------------- */
 
 function getRandomId(length = 16) {
-  const digits = Number('1'.padEnd(length + 1, '0'));
+  length = length > 16 ? 16 : length;
 
-  return `${Math.floor(Math.random() * digits) + 1}`;
+  const digits = Number('1'.padEnd(length, '0'));
+
+  return `${Math.floor(Math.random() * digits)}`.padEnd(length, '0').substring(0, length);
 }
 
 /* -----------------------------------
@@ -34,7 +36,7 @@ function getHash(value: string, length = 16) {
     hash = hash & hash;
   }
 
-  return `${hash & 0xffff}`.padStart(length, '0');
+  return `${hash & 0xffff}`.padStart(length, '0').substring(0, length);
 }
 
 /* -----------------------------------

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -15,7 +15,26 @@ function debounce(callback: TimerHandler, frequency = 500, timer = 0) {
  * -------------------------------- */
 
 function getRandomId(length = 16) {
-  return `${Math.floor(Math.random() * 1e16) + 1}`;
+  const digits = Number('1'.padEnd(length + 1, '0'));
+
+  return `${Math.floor(Math.random() * digits) + 1}`;
+}
+
+/* -----------------------------------
+ *
+ * Hash
+ *
+ * -------------------------------- */
+
+function getHash(value: string, length = 16) {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index++) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash = hash & hash;
+  }
+
+  return `${hash & 0xffff}`.padStart(length, '0');
 }
 
 /* -----------------------------------
@@ -49,4 +68,4 @@ function getScrollPercentage() {
  *
  * -------------------------------- */
 
-export { debounce, getRandomId, getScrollPercentage };
+export { debounce, getRandomId, getHash, getScrollPercentage };

--- a/packages/shared/tests/utility.test.ts
+++ b/packages/shared/tests/utility.test.ts
@@ -1,13 +1,65 @@
+import { getRandomId, getHash } from '../src/utility';
+
+/* -----------------------------------
+ *
+ * Variables
+ *
+ * -------------------------------- */
+
+const hashSeed = `${Math.random()}`;
+
 /* -----------------------------------
  *
  * Shared
  *
  * -------------------------------- */
 
-describe('shared', () => {
-  describe('utility', () => {
-    it('needs tests', () => {
-      expect(true).toBe(true);
+describe('shared -> utility', () => {
+  describe('getRandomId', () => {
+    it('generates a unique ID after every call', () => {
+      const result = getRandomId();
+
+      expect(result).not.toEqual(getRandomId());
+      expect(result).not.toEqual(getRandomId());
+      expect(result).not.toEqual(getRandomId());
+    });
+
+    it('generates an ID of correct length', () => {
+      const lengths = [8, 12, 16];
+
+      lengths.forEach((length) => {
+        expect(getRandomId(length).length).toEqual(length);
+      });
+    });
+
+    it('limits character length to 16 digits', () => {
+      const lengths = [32, 64, 128];
+
+      lengths.forEach((length) => {
+        expect(getRandomId(length).length).toEqual(16);
+      });
+    });
+  });
+
+  describe('getHash', () => {
+    it('generates a hash string from an input seed', () => {
+      const iterations = new Array(5);
+
+      const result = getHash(hashSeed);
+
+      expect(result).not.toEqual(hashSeed);
+
+      iterations.forEach(() => {
+        expect(result).toEqual(getHash(hashSeed));
+      });
+    });
+
+    it('generates a hash of correct length', () => {
+      const lengths = [8, 16, 32, 64];
+
+      lengths.forEach((length) => {
+        expect(getHash(hashSeed, length).length).toEqual(length);
+      });
     });
   });
 });


### PR DESCRIPTION
- Added param model to allow for easier maintenance of future API changes
- Refactored one dimensional object into an array of tuples
- Modified how event data is a added to payload value
- Added further tests to `shared` package
- The value for `?_p` (pageId) is now a reproducible hash, using the location as a seed