### PR TITLE
fix: engagement and scroll event issue

### DIFF
--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement and scroll tracking",
   "author": "James Hill <jahill@groupon.com>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  EventParams,
   debounce,
   getDocument,
   getClientId,
@@ -6,6 +7,7 @@ import {
   getSessionState,
   getScrollPercentage,
   getHashId,
+  getEventParams,
 } from '@minimal-analytics/shared';
 import { param } from './model';
 
@@ -33,7 +35,7 @@ declare global {
 
 interface IProps {
   type?: string;
-  event?: Record<string, number>;
+  event?: EventParams;
   debug?: boolean;
   error?: {
     message: string;
@@ -107,7 +109,7 @@ function getEventMeta({ type, event }: Pick<IProps, 'type' | 'event'>) {
   ];
 
   if (event) {
-    payload = payload.concat(Object.keys(event).map((key) => [key, `${event[key]}`]));
+    payload = payload.concat(getEventParams(event));
   }
 
   return payload;
@@ -183,7 +185,7 @@ const onScrollEvent = debounce((trackingId: string) => {
 
   track(trackingId, {
     type: eventKeys.scroll,
-    event: { [`${param.eventParamNumber}.percent_scrolled`]: 90 },
+    event: [[`${param.eventParamNumber}.percent_scrolled`, 90]],
   });
 
   document.removeEventListener('scroll', scrollHandler);
@@ -196,14 +198,13 @@ const onScrollEvent = debounce((trackingId: string) => {
  * -------------------------------- */
 
 function onUnloadEvent(trackingId: string) {
-  const timeActive = engagementTimes.reduce(
-    (result, [visible, hidden = Date.now()]) => (result += hidden - visible),
-    0
-  );
+  const timeActive = engagementTimes
+    .reduce((result, [visible, hidden = Date.now()]) => (result += hidden - visible), 0)
+    .toString();
 
   track(trackingId, {
     type: eventKeys.userEngagement,
-    event: { [param.enagementTime]: timeActive },
+    event: [[param.enagementTime, timeActive]],
   });
 }
 

--- a/packages/ga4/webpack.config.ts
+++ b/packages/ga4/webpack.config.ts
@@ -2,6 +2,7 @@ import { Configuration, DefinePlugin } from 'webpack';
 import nodeExternals from 'webpack-node-externals';
 import TerserPlugin from 'terser-webpack-plugin';
 import * as path from 'path';
+import { param } from './src/model';
 
 /* -----------------------------------
  *
@@ -110,6 +111,8 @@ const config = ({ mode }): Configuration[] =>
                   'trackingId',
                   'autoTrack',
                   'analyticsEndpoint',
+                  // prevent params being mangled
+                  ...Object.keys(param),
                 ],
               },
             },

--- a/packages/heap/package.json
+++ b/packages/heap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/heap",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A tiny (1KB GZipped) version of Heap, complete with page view and input tracking",
   "author": "James Hill <jahill@groupon.com>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/heap#readme",

--- a/packages/heap/webpack.config.ts
+++ b/packages/heap/webpack.config.ts
@@ -2,6 +2,7 @@ import { Configuration, DefinePlugin } from 'webpack';
 import nodeExternals from 'webpack-node-externals';
 import TerserPlugin from 'terser-webpack-plugin';
 import * as path from 'path';
+import { param } from './src/model';
 
 /* -----------------------------------
  *
@@ -110,6 +111,8 @@ const config = ({ mode }): Configuration[] =>
                   'trackingId',
                   'autoTrack',
                   'analyticsEndpoint',
+                  // prevent params being mangled
+                  ...Object.keys(param),
                 ],
               },
             },

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
   coverageThreshold: {
     global: {
-      statements: 54,
+      statements: 58,
       branches: 50,
       functions: 40,
-      lines: 47,
+      lines: 50,
     },
   },
   transform: {

--- a/packages/shared/src/payload.ts
+++ b/packages/shared/src/payload.ts
@@ -2,6 +2,14 @@ import { getRandomId } from './utility';
 
 /* -----------------------------------
  *
+ * Types
+ *
+ * -------------------------------- */
+
+type EventParams = Record<string, string | number> | (string | number)[][];
+
+/* -----------------------------------
+ *
  * Variables
  *
  * -------------------------------- */
@@ -101,11 +109,26 @@ function getSessionState(firstEvent: boolean) {
 
 /* -----------------------------------
  *
+ * EventPrams
+ *
+ * -------------------------------- */
+
+function getEventParams(event: EventParams) {
+  if (Array.isArray(event)) {
+    return event.map((items) => items.map((item) => item.toString()));
+  }
+
+  return Object.keys(event).map((key) => [key, `${event[key]}`]);
+}
+
+/* -----------------------------------
+ *
  * Export
  *
  * -------------------------------- */
 
 export {
+  EventParams,
   clientKey,
   sessionKey,
   counterKey,
@@ -113,4 +136,5 @@ export {
   getClientId,
   getSessionId,
   getSessionState,
+  getEventParams,
 };

--- a/packages/shared/tests/payload.test.ts
+++ b/packages/shared/tests/payload.test.ts
@@ -1,0 +1,43 @@
+import { EventParams, getEventParams } from '../src/payload';
+
+/* -----------------------------------
+ *
+ * Variables
+ *
+ * -------------------------------- */
+
+const testQuery1 = 'testQuery1';
+const testQuery2 = 'testQuery2';
+const testStringValue = `testValue-${Math.random()}`;
+const testNumberValue = Math.random();
+
+/* -----------------------------------
+ *
+ * Shared
+ *
+ * -------------------------------- */
+
+describe('shared -> payload', () => {
+  describe('getEventParams', () => {
+    it('returns a multidimensional array of strings from an input object', () => {
+      const event = { [testQuery1]: testStringValue, [testQuery2]: testNumberValue };
+      const result = getEventParams(event);
+
+      expect(result).toEqual([
+        [testQuery1, testStringValue],
+        [testQuery2, `${testNumberValue}`],
+      ]);
+    });
+
+    it('returns input if already a multidimensional array and casts to string', () => {
+      const event = [
+        [testQuery1, testStringValue],
+        [testQuery2, testNumberValue],
+      ];
+
+      const result = getEventParams(event);
+
+      expect(result).toEqual(event.map((items) => items.map((item) => item.toString())));
+    });
+  });
+});


### PR DESCRIPTION
Following [the output size reduction](https://github.com/jahilldev/minimal-analytics/pull/12), some GA params are being incorrectly mangled, causing missing data. This PR addresses and fixes that issue.

- Add param model to minification whitelist
- Converted internal event model to multidimensional array
- Added additional unit tests for `getEventParams`