### PR TITLE
feat: added click tracking as provided by official GA4 script

### DIFF
--- a/packages/ga4/jest.config.js
+++ b/packages/ga4/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 90,
-      branches: 69,
+      branches: 68,
       functions: 93,
       lines: 89,
     },

--- a/packages/ga4/jest.config.js
+++ b/packages/ga4/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
   coverageThreshold: {
     global: {
-      statements: 90,
-      branches: 68,
-      functions: 93,
-      lines: 89,
+      statements: 96,
+      branches: 71,
+      functions: 100,
+      lines: 96,
     },
   },
   transform: {

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.5.2",
-  "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement and scroll tracking",
+  "version": "1.6.0",
+  "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement, scroll and click tracking",
   "author": "James Hill <jahill@groupon.com>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",
   "license": "MIT",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -189,7 +189,7 @@ function onClickEvent(trackingId: string, event: Event) {
     event: [
       [`${elementParam}_id`, targetElement.id],
       [`${elementParam}_classes`, targetElement.className],
-      [`${elementParam}_text`, targetElement.textContent],
+      [`${elementParam}_text`, targetElement.textContent.trim()],
       [`${elementParam}_domain`, urlData?.hostname],
       [`${param.eventParam}.outbound`, `${isOutboundLink}`],
       [param.enagementTime, getActiveTime()],

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -176,20 +176,20 @@ function onClickEvent(trackingId: string, event: Event) {
   const tagName = targetElement.tagName?.toLowerCase();
   const elementType = tagName === 'a' ? 'link' : tagName;
   const elementParam = `${param.eventParam}.${elementType}`;
+  const hrefAttr = targetElement?.getAttribute('href');
+  const { isExternal, hostname, pathname } = getUrlData(hrefAttr);
+  const isInternalLink = elementType === 'link' && hostname && !isExternal;
 
-  if (!targetElement) {
+  if (!targetElement || isInternalLink) {
     return;
   }
-
-  const hrefAttr = targetElement.getAttribute('href');
-  const { isExternal, hostname, pathname } = getUrlData(hrefAttr);
 
   track(trackingId, {
     type: eventKeys.click,
     event: [
       [`${elementParam}_id`, targetElement.id],
       [`${elementParam}_classes`, targetElement.className],
-      [`${elementParam}_text`, targetElement.textContent.trim()],
+      [`${elementParam}_text`, targetElement.textContent?.trim()],
       [`${elementParam}_domain`, hostname],
       [`${elementParam}_path`, pathname],
       [`${param.eventParam}.outbound`, `${isExternal}`],

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -176,13 +176,13 @@ function onClickEvent(trackingId: string, event: Event) {
   const elementType = tagName === 'a' ? 'link' : tagName;
   const elementParam = `${param.eventParam}.${elementType}`;
 
-  const hrefAttr = targetElement.getAttribute('href');
-  const urlData = hrefAttr && new URL(hrefAttr);
-  const isOutboundLink = urlData?.hostname !== window.location.host;
-
   if (!targetElement) {
     return;
   }
+
+  const hrefAttr = targetElement.getAttribute('href');
+  const urlData = hrefAttr && new URL(hrefAttr);
+  const isOutboundLink = urlData?.hostname !== window.location.host;
 
   track(trackingId, {
     type: eventKeys.click,

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -8,6 +8,7 @@ import {
   getScrollPercentage,
   getRandomId,
   isTargetElement,
+  getUrlData,
   getEventParams,
 } from '@minimal-analytics/shared';
 import { param } from './model';
@@ -181,8 +182,7 @@ function onClickEvent(trackingId: string, event: Event) {
   }
 
   const hrefAttr = targetElement.getAttribute('href');
-  const urlData = hrefAttr && new URL(hrefAttr);
-  const isOutboundLink = urlData?.hostname !== window.location.host;
+  const { isExternal, hostname, pathname } = getUrlData(hrefAttr);
 
   track(trackingId, {
     type: eventKeys.click,
@@ -190,8 +190,9 @@ function onClickEvent(trackingId: string, event: Event) {
       [`${elementParam}_id`, targetElement.id],
       [`${elementParam}_classes`, targetElement.className],
       [`${elementParam}_text`, targetElement.textContent.trim()],
-      [`${elementParam}_domain`, urlData?.hostname],
-      [`${param.eventParam}.outbound`, `${isOutboundLink}`],
+      [`${elementParam}_domain`, hostname],
+      [`${elementParam}_path`, pathname],
+      [`${param.eventParam}.outbound`, `${isExternal}`],
       [param.enagementTime, getActiveTime()],
     ],
   });

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -7,6 +7,7 @@ import {
   getSessionState,
   getScrollPercentage,
   getRandomId,
+  isTargetElement,
   getEventParams,
 } from '@minimal-analytics/shared';
 import { param } from './model';
@@ -65,6 +66,7 @@ let engagementTimes = [[Date.now()]];
 const eventKeys = {
   pageView: 'page_view',
   scroll: 'scroll',
+  click: 'click',
   viewSearchResults: 'view_search_results',
   userEngagement: 'user_engagement',
 };
@@ -156,9 +158,15 @@ function getQueryParams(trackingId: string, { type, event, debug }: IProps) {
 
 function onClickEvent(trackingId: string, event: Event) {
   const target = event.target as HTMLElement;
-  const isValidTarget = target.matches('a, button');
+  const isValidTarget = isTargetElement(target, 'a, button');
 
-  console.log('onClickEvent', { trackingId, isValidTarget });
+  if (!isValidTarget) {
+    return;
+  }
+
+  // TODO
+  // - Send "click" event with relevant params
+  // track(trackingId, { type: eventKeys.click, event: { ... } });
 }
 
 /* -----------------------------------

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -1,5 +1,6 @@
 import { clientKey, counterKey, sessionKey } from '@minimal-analytics/shared';
 import { track } from '../src/index';
+import { param } from '../src/model';
 
 /* -----------------------------------
  *
@@ -95,12 +96,12 @@ describe('ga4 -> track()', () => {
   it('defines the correct query params when sending a default page view', () => {
     const params = [
       analyticsEndpoint,
-      `v=${analyticsVersion}`,
-      `tid=${trackingId}`,
-      `ul=${testLanguage}`,
-      'en=page_view',
-      `dr=${encodeURIComponent(testUrl)}`,
-      `dt=${encodeURIComponent(testTitle)}`,
+      `${param.protocolVersion}=${analyticsVersion}`,
+      `${param.trackingId}=${trackingId}`,
+      `${param.language}=${testLanguage}`,
+      `${param.eventName}=page_view`,
+      `${param.referrer}=${encodeURIComponent(testUrl)}`,
+      `${param.title}=${encodeURIComponent(testTitle)}`,
     ];
 
     track(trackingId);
@@ -133,9 +134,15 @@ describe('ga4 -> track()', () => {
   });
 
   it('defines the correct query param when sending a custom event', () => {
-    const params = [`en=${testEvent}`, `ep.random=${testData}`];
+    const params = [
+      `${param.eventName}=${testEvent}`,
+      `${param.eventParamNumber}.random=${testData}`,
+    ];
 
-    track(trackingId, { type: testEvent, event: { 'ep.random': testData } });
+    track(trackingId, {
+      type: testEvent,
+      event: { [`${param.eventParamNumber}.random`]: testData },
+    });
 
     expect(navigator.sendBeacon).toBeCalledTimes(1);
 
@@ -173,7 +180,8 @@ describe('ga4 -> track()', () => {
 
     document.dispatchEvent(event);
 
-    expect(navigator.sendBeacon).toBeCalledTimes(2);
+    // TODO
+    // expect(navigator.sendBeacon).toBeCalledTimes(2);
   });
 
   it('triggers a tracking event once when scroll is 90% of window', async () => {

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -19,10 +19,15 @@ const testWidth = 1600;
 const testHeight = 900;
 const testEvent = 'custom_event';
 const testData = Math.random();
-const testLink = 'https://google.com';
+const testDomain = 'google.com';
+const testLink = `https://${testDomain}/hello`;
+const testId = 'testId';
+const testClass = 'testClass';
 const testAnchor = `
   <main>
-    <a href="${testLink}">${testTitle}</a>
+    <a href="${testLink}" id="${testId}" class="${testClass}">
+      <span>${testTitle}</span>
+    </a>
   </main>
 `;
 
@@ -167,6 +172,15 @@ describe('ga4 -> track()', () => {
   });
 
   it('triggers a tracking event when a target element is clicked', async () => {
+    const params = [
+      `${param.eventName}=click`,
+      `${param.eventParam}.link_id=${testId}`,
+      `${param.eventParam}.link_classes=${testClass}`,
+      `${param.eventParam}.link_text=${testTitle}`,
+      `${param.eventParam}.link_domain=${testDomain}`,
+      `${param.eventParam}.outbound=true`,
+    ];
+
     root.innerHTML = testAnchor;
 
     track(trackingId);
@@ -180,8 +194,14 @@ describe('ga4 -> track()', () => {
 
     document.dispatchEvent(event);
 
-    // TODO
-    // expect(navigator.sendBeacon).toBeCalledTimes(2);
+    expect(navigator.sendBeacon).toBeCalledTimes(2);
+
+    params.forEach((param) =>
+      expect(navigator.sendBeacon).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(param)
+      )
+    );
   });
 
   it('triggers a tracking event once when scroll is 90% of window', async () => {

--- a/packages/ga4/tests/ga4.test.ts
+++ b/packages/ga4/tests/ga4.test.ts
@@ -250,7 +250,7 @@ describe('ga4 -> track()', () => {
 
     expect(navigator.sendBeacon).toBeCalledTimes(2);
     expect(navigator.sendBeacon).toBeCalledWith(
-      expect.stringContaining('en=user_engagement')
+      expect.stringContaining(`${param.eventName}=user_engagement`)
     );
   });
 });

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
   coverageThreshold: {
     global: {
-      statements: 58,
-      branches: 50,
-      functions: 40,
-      lines: 50,
+      statements: 59,
+      branches: 52,
+      functions: 42,
+      lines: 58,
     },
   },
   transform: {

--- a/packages/shared/src/payload.ts
+++ b/packages/shared/src/payload.ts
@@ -115,7 +115,7 @@ function getSessionState(firstEvent: boolean) {
 
 function getEventParams(event: EventParams) {
   if (Array.isArray(event)) {
-    return event.map((items) => items.map((item) => item.toString()));
+    return event.map((items) => items.map((item) => item?.toString()));
   }
 
   return Object.keys(event).map((key) => [key, `${event[key]}`]);

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -70,8 +70,28 @@ function getScrollPercentage() {
 
 /* -----------------------------------
  *
+ * TargetElement
+ *
+ * -------------------------------- */
+
+function isTargetElement(element: Element, selector: string) {
+  let target = element;
+
+  while (test && target !== element) {
+    target = target.parentNode as Element;
+
+    if (target.matches(selector)) {
+      break;
+    }
+  }
+
+  return target;
+}
+
+/* -----------------------------------
+ *
  * Export
  *
  * -------------------------------- */
 
-export { debounce, getRandomId, getHashId, getScrollPercentage };
+export { debounce, getRandomId, getHashId, getScrollPercentage, isTargetElement };

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -74,13 +74,13 @@ function getScrollPercentage() {
  *
  * -------------------------------- */
 
-function isTargetElement(element: Element, selector: string) {
+function isTargetElement(element: Element, selector: string): Element | undefined {
   let target = element;
 
-  while (test && target !== element) {
+  while (target) {
     target = target.parentNode as Element;
 
-    if (target.matches(selector)) {
+    if (!target || target.matches(selector)) {
       break;
     }
   }

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -74,15 +74,15 @@ function getScrollPercentage() {
  *
  * -------------------------------- */
 
-function isTargetElement(element: Element, selector: string): Element | undefined {
+function isTargetElement(element: Element, selector: string): Element | null {
   let target = element;
 
   while (target) {
-    target = target.parentNode as Element;
-
-    if (!target || target.matches(selector)) {
+    if (target?.matches(selector)) {
       break;
     }
+
+    target = target?.parentNode as Element;
   }
 
   return target;

--- a/packages/shared/src/utility.ts
+++ b/packages/shared/src/utility.ts
@@ -90,8 +90,33 @@ function isTargetElement(element: Element, selector: string): Element | null {
 
 /* -----------------------------------
  *
+ * UrlData
+ *
+ * -------------------------------- */
+
+function getUrlData(urlValue?: string) {
+  const { hostname, pathname } = (urlValue && new URL(urlValue)) || {};
+
+  let isExternal = false;
+
+  if (hostname) {
+    isExternal = hostname !== window.location.host;
+  }
+
+  return { isExternal, hostname, pathname };
+}
+
+/* -----------------------------------
+ *
  * Export
  *
  * -------------------------------- */
 
-export { debounce, getRandomId, getHashId, getScrollPercentage, isTargetElement };
+export {
+  debounce,
+  getRandomId,
+  getHashId,
+  getScrollPercentage,
+  isTargetElement,
+  getUrlData,
+};

--- a/packages/shared/tests/payload.test.ts
+++ b/packages/shared/tests/payload.test.ts
@@ -1,4 +1,4 @@
-import { EventParams, getEventParams } from '../src/payload';
+import { getEventParams } from '../src/payload';
 
 /* -----------------------------------
  *
@@ -10,6 +10,8 @@ const testQuery1 = 'testQuery1';
 const testQuery2 = 'testQuery2';
 const testStringValue = `testValue-${Math.random()}`;
 const testNumberValue = Math.random();
+const localUrl = 'http://localhost/test';
+const remoteUrl = 'https://www.google.com/test';
 
 /* -----------------------------------
  *

--- a/packages/shared/tests/utility.test.ts
+++ b/packages/shared/tests/utility.test.ts
@@ -63,7 +63,17 @@ describe('shared -> utility', () => {
   });
 
   describe('isTargetElement', () => {
-    it('returns true if element matches selector', () => {
+    it('returns element if matched by provided selector', () => {
+      const target = document.createElement('a');
+      const selector = 'a';
+
+      const result = isTargetElement(target, selector);
+
+      expect(result).not.toBe(null);
+      expect(result?.tagName.toLowerCase()).toBe(selector);
+    });
+
+    it('returns element if matched in parent tree by selector', () => {
       const wrapper = document.createElement('section');
       const html = `<a href="#"><div><span>Link</span></div></a>`;
       const selector = 'a';
@@ -73,8 +83,22 @@ describe('shared -> utility', () => {
       const target = wrapper.querySelector('span');
       const result = isTargetElement(target, selector);
 
-      expect(result).not.toBe(void 0);
+      expect(result).not.toBe(null);
       expect(result?.tagName.toLowerCase()).toBe(selector);
+    });
+
+    it('returns null if element does not match selector', () => {
+      const wrapper = document.createElement('section');
+      const html = `<a href="#"><div><span>Link</span></div></a>`;
+      const selector = 'button';
+
+      wrapper.innerHTML = html;
+
+      const target = wrapper.querySelector('span');
+      const result = isTargetElement(target, selector);
+
+      expect(result).toBe(null);
+      expect(result?.tagName.toLowerCase()).not.toBe(selector);
     });
   });
 });

--- a/packages/shared/tests/utility.test.ts
+++ b/packages/shared/tests/utility.test.ts
@@ -1,4 +1,4 @@
-import { getRandomId, getHashId } from '../src/utility';
+import { getRandomId, getHashId, isTargetElement } from '../src/utility';
 
 /* -----------------------------------
  *
@@ -59,6 +59,22 @@ describe('shared -> utility', () => {
       lengths.forEach((length) => {
         expect(getHashId(hashSeed, length).length).toEqual(length);
       });
+    });
+  });
+
+  describe('isTargetElement', () => {
+    it('returns true if element matches selector', () => {
+      const wrapper = document.createElement('section');
+      const html = `<a href="#"><div><span>Link</span></div></a>`;
+      const selector = 'a';
+
+      wrapper.innerHTML = html;
+
+      const target = wrapper.querySelector('span');
+      const result = isTargetElement(target, selector);
+
+      expect(result).not.toBe(void 0);
+      expect(result?.tagName.toLowerCase()).toBe(selector);
     });
   });
 });


### PR DESCRIPTION
The GA4 script now provides `click` event tracking, explicitly on element types `a` and `button`. This now brings `@minimal-analytics/ga4` fully in-line with the default event tracking types that GA4 provides out of the box.

- Listen for clicks on `<a />` and `<button />` elements **_only_**
- Sends correct event payload to GA4 endpoint, included element meta
- Updated test cases to cover this new functionality
