### PR TITLE
fix: removed mouseenter event

### DIFF
--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -203,14 +203,14 @@ function onClickEvent(trackingId: string, event: Event) {
  *
  * -------------------------------- */
 
-function onBlurEvent() {
+const onBlurEvent = debounce(() => {
   const timeIndex = engagementTimes.length - 1;
   const [, isHidden] = engagementTimes[timeIndex];
 
   if (!isHidden) {
     engagementTimes[timeIndex].push(Date.now());
   }
-}
+});
 
 /* -----------------------------------
  *

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -297,7 +297,6 @@ function bindEvents(trackingId: string) {
   unloadHandler = onUnloadEvent.bind(null, trackingId);
 
   document.addEventListener('visibilitychange', onVisibilityChange);
-  document.addEventListener('mouseenter', onFocusEvent);
   document.addEventListener('scroll', scrollHandler);
   document.addEventListener('click', clickHandler);
 


### PR DESCRIPTION
If a user causes the `blur` event to fire, currently we're re-engaging a user on `mouseenter`. This is problematic, as there isn't a way for us to dis-engage again reliably (`mouseleave` won't give us an accurate reading on visibility), given the window is still in a `blur` state. 

This can cause incredibly high engagement times, depending on how long the window is in this state (24hrs+++), if not closed. This is only really an issue in very specific, edge case scenarios.

Removing the `mouseenter` event aligns better with the official GA4 implementation, but won't account for visible, but blurred, windows. This is a tricky problem, and not easily solved.

For now, this is a good compromise, removing enormous, inaccurate spikes in engagement.