### PR TITLE
feat: added global window definition for ease of use

### DIFF
--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -72,6 +72,18 @@ track({ type: 'user_signup', event: { 'epn.user_id': 12345, 'ep.user_name': 'Joh
 
 **Note**: It's generally best practice (or advised) to prefix any `event` properties with `ep.` or `epn.` to ensure there are no future conflicts with official GA4 parameters. If you require GA4 to parse a parameter as a number, use the prefix `epn.`, if not, use `ep.` at the start of your object key.
 
+## Global
+
+If you'd like the `track` function to be defined on the Window, e.g `window.track()`, you'll need to define the following property prior to loading the `@minimal-analytics/ga4` package, or script:
+
+```js
+window.minimalAnalytics = {
+  defineGlobal: true,
+};
+```
+
+This will allow you to access the `track` function throughout your application.
+
 ## Onload
 
 If you'd prefer to let the `ga4` script initialise tracking itself when loaded, you can define the following property on the window, prior to including the script on the page:

--- a/packages/ga4/jest.config.js
+++ b/packages/ga4/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '(.*).d.ts'],
   coverageThreshold: {
     global: {
-      statements: 97,
+      statements: 96,
       branches: 78,
       functions: 100,
       lines: 96,

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement, scroll and click tracking",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",

--- a/packages/ga4/src/index.ts
+++ b/packages/ga4/src/index.ts
@@ -21,7 +21,9 @@ import { param, files } from './model';
 
 declare global {
   interface Window {
+    track?: typeof track;
     minimalAnalytics?: {
+      defineGlobal?: boolean;
       analyticsEndpoint?: string;
       trackingId?: string;
       autoTrack?: boolean;
@@ -48,6 +50,7 @@ interface IProps {
  * -------------------------------- */
 
 const isBrowser = typeof window !== 'undefined';
+const defineGlobal = isBrowser && window.minimalAnalytics?.defineGlobal;
 const autoTrack = isBrowser && window.minimalAnalytics?.autoTrack;
 const analyticsEndpoint = 'https://www.google-analytics.com/g/collect';
 const searchTerms = ['q', 's', 'search', 'query', 'keyword'];
@@ -353,6 +356,16 @@ function track(...args: any[]) {
   bindEvents(trackingId);
 
   trackCalled = true;
+}
+
+/* -----------------------------------
+ *
+ * Define
+ *
+ * -------------------------------- */
+
+if (defineGlobal) {
+  window.track = track;
 }
 
 /* -----------------------------------

--- a/packages/heap/src/index.ts
+++ b/packages/heap/src/index.ts
@@ -15,6 +15,7 @@ import { param } from './model';
 declare global {
   interface Window {
     minimalAnalytics?: {
+      defineGlobal?: boolean;
       analyticsEndpoint?: string;
       trackingId?: string;
       autoTrack?: boolean;


### PR DESCRIPTION
Currently if a consumer does not make use of Node, or a build tool built in Node, it's not possible to access the `track` function globally inside an applications code.

This introduces an additional config property, `defineGlobal`, that can be set to handle this definition. You can access the function by calling:

```js
window.track(/*[...]*/);
```