### PR TITLE
fix: whitelist defineGlobal property

### DIFF
--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement, scroll and click tracking",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",

--- a/packages/ga4/webpack.config.ts
+++ b/packages/ga4/webpack.config.ts
@@ -111,6 +111,7 @@ const config = ({ mode }): Configuration[] =>
                   'trackingId',
                   'autoTrack',
                   'analyticsEndpoint',
+                  'defineGlobal',
                   // prevent params being mangled
                   ...Object.keys(param),
                 ],


### PR DESCRIPTION
A previous PR missed the reserve list item for `defineGlobal`, causing it to be mangled. 

This PR fixed that.