### PR TITLE
chore: updated jsdelivr cdn url

### DIFF
--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -114,7 +114,7 @@ This value will supercede the default Google Analytics endpoint if defined.
 If you're not running or building your application in a Node environment, you can use one of the following CDN's to include the script on your page:
 
 - https://unpkg.com/@minimal-analytics/ga4/dist/index.js
-- https://cdn.jsdelivr.net/npm/@minimal-analytics/ga4@latest/dist/index.js
+- https://cdn.jsdelivr.net/npm/@minimal-analytics/ga4/dist/index.js
 
 Alternatively, you can download the script from any of the links above and host it yourself.
 

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement, scroll and click tracking",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",


### PR DESCRIPTION
The curred JSDelivr CDN url is cached for up to 12hrs at the server level, but also set `max-age` for up to 7 days. This can cause a user to cache the file for up to a week.

This is problematic in case of bug fixes, or if a user of the package wants to make use of a new feature.

We've now switched the url to use a version less format, which should provide the latest version instantly.