### PR TITLE
feat: added download attr support for non anchor click elements

### DIFF
--- a/packages/ga4/README.md
+++ b/packages/ga4/README.md
@@ -72,6 +72,20 @@ track({ type: 'user_signup', event: { 'epn.user_id': 12345, 'ep.user_name': 'Joh
 
 **Note**: It's generally best practice (or advised) to prefix any `event` properties with `ep.` or `epn.` to ensure there are no future conflicts with official GA4 parameters. If you require GA4 to parse a parameter as a number, use the prefix `epn.`, if not, use `ep.` at the start of your object key.
 
+### Download
+
+Download tracking happens automatically based on whether or not an anchor's `href` or `download` attribute contains a supported file URL (see list [here](https://github.com/jahilldev/minimal-analytics/blob/main/packages/ga4/src/model.ts#L36)). If you provide downloads that are not accessible by the client, for example, behind a form submission or CSRF based system, you can apply a `download` attribute with a value of a valid link url to trigger the event.
+
+For example, all of these will trigger a GA4 download event:
+
+```html
+<a href="https://download.com/file.pdf">Download</a>
+<a href="https://download.com/file.pdf" download>Download</a>
+<button download="https://download.com/file.pdf">Download</button>
+<input type="submit" download="https://download.com/file.pdf" value="Download" />
+<input type="button" download="https://download.com/file.pdf" value="Download" />
+```
+
 ## Global
 
 If you'd like the `track` function to be defined on the Window, e.g `window.track()`, you'll need to define the following property prior to loading the `@minimal-analytics/ga4` package, or script:

--- a/packages/ga4/package.json
+++ b/packages/ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimal-analytics/ga4",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "A tiny (2KB GZipped) version of GA4, complete with page view, engagement, scroll and click tracking",
   "author": "James Hill <contact@jameshill.dev>",
   "homepage": "https://github.com/jahilldev/minimal-analytics/tree/main/packages/ga4#readme",

--- a/packages/ga4/tests/index.test.ts
+++ b/packages/ga4/tests/index.test.ts
@@ -32,6 +32,7 @@ const testAnchor = `
     </a>
     <a href="/" id="internal">${testTitle}</a>
     <a href="${testFile}" id="download">${testTitle}</a>
+    <button download="${testFile}">${testTitle}</button>
   </main>
 `;
 
@@ -291,7 +292,7 @@ describe('ga4 -> track()', () => {
     expect(navigator.sendBeacon).toBeCalledTimes(1);
   });
 
-  it('triggers a download tracking event when a file link is clicked', async () => {
+  it('triggers a download tracking event when a file anchor is clicked', async () => {
     const params = [
       `${param.eventName}=file_download`,
       `${param.eventParam}.link_id=download`,
@@ -312,6 +313,38 @@ describe('ga4 -> track()', () => {
     const event = new CustomEvent('click');
 
     Object.defineProperty(event, 'target', { value: link });
+
+    document.dispatchEvent(event);
+
+    expect(navigator.sendBeacon).toBeCalledTimes(2);
+
+    params.forEach((param) =>
+      expect(navigator.sendBeacon).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(param)
+      )
+    );
+  });
+
+  it('triggers a download tracking event when an element with a download attribute is clicked', async () => {
+    const params = [
+      `${param.eventName}=file_download`,
+      `${param.eventParam}.button_text=${testTitle}`,
+      `${param.eventParam}.file_name=${encodeURIComponent(testFile)}`,
+      `${param.eventParam}.file_extension=${testExtension}`,
+      `${param.eventParam}.outbound=false`,
+    ];
+
+    root.innerHTML = testAnchor;
+
+    track(trackingId);
+
+    expect(navigator.sendBeacon).toBeCalledTimes(1);
+
+    const button = root.querySelector('button');
+    const event = new CustomEvent('click');
+
+    Object.defineProperty(event, 'target', { value: button });
 
     document.dispatchEvent(event);
 


### PR DESCRIPTION
Although not *strictly* valid syntax, having the ability to indicate elements other than `<a />` as download triggers is very useful from an analytics point of view.

The following elements can now trigger a download event by applying the relevant attribute (`download`, [see here](https://www.w3schools.com/tags/att_a_download.asp)) with a respective value:
- `<a />` (pre existing)
- `<button />` (must have value for `download`)
- `<input />` (only types of `submit` and `button`, must have value for attribute)

The following example will correctly trigger a download tracking event for a download triggered by some kind of server led system:

```html
<form>
  <input type="submit" value="Download" download="https://path.com/to/my/file.pdf" />
</form>
```